### PR TITLE
refactor: Add more details on LVFR Compatibility addons of Horizon Simulations

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -149,18 +149,26 @@ const config: Configuration = {
                         },
                     ],
                     incompatibleAddons: [
+                        // title: the exact title as it appears in the manifest.json
+                        // creator: the exact creator as it appears in the manifest.json
                         // packageVersion syntax follows: https://www.npmjs.com/package/semver
+                        // description: a short description of why the addon is incompatible
+                        {
+                            title: 'Horizon Simulations A319ceo',
+                            packageVersion: '<0.6.1',
+                            description: "It is recommended to upgrade to the latest version (0.6.0 or later) or to remove this add-on before installing and using the A32NX. The older versions of this add-on are known to override A32NX components and to break the A32NX.",
+                        },
+                        {
+                            title: 'Horizon Simulations A321neo',
+                            packageVersion: '<0.4.0',
+                            description: "It is recommended to remove this add-on before installing and using the A32NX. This add-on is known to override A32NX components and cause unexpected behavior and issues when flying the A32NX.",
+                        },
                         {
                             title: 'LVFR A321neo FBW A32NX Compatibility Mod',
-                            creator: 'TJC.Aviation',
                             description: "It is recommended to remove this add-on before installing and using the A32NX. This add-on is known to override A32NX components and to break the A32NX.",
                         },
                         {
                             title: 'LVFR A321neo Extreme',
-                            description: "It is recommended to remove this add-on before installing and using the A32NX. This add-on is known to override A32NX components and cause unexpected behavior and issues when flying the A32NX.",
-                        },
-                        {
-                            title: 'Horizon Simulations A321neo',
                             description: "It is recommended to remove this add-on before installing and using the A32NX. This add-on is known to override A32NX components and cause unexpected behavior and issues when flying the A32NX.",
                         },
                         {
@@ -169,18 +177,11 @@ const config: Configuration = {
                             description: "It is recommended to upgrade to the latest version (0.6.0 or later) or to remove this add-on before installing and using the A32NX. The older versions of this add-on are known to override A32NX components and to break the A32NX.",
                         },
                         {
-                            title: 'Horizon Simulations A319ceo',
-                            packageVersion: '<0.6.0',
-                            description: "It is recommended to upgrade to the latest version (0.6.0 or later) or to remove this add-on before installing and using the A32NX. The older versions of this add-on are known to override A32NX components and to break the A32NX.",
-                        },
-                        {
                             title: '[MOD] Mugz FBW A32NX Dev',
-                            creator: "Mugz",
                             description: "It is required to remove this add-on before installing and using the A32NX. This add-on overrides A32NX components and renders the A32NX unusable.",
                         },
                         {
                             title: '[MOD] Mugz FBW A32NX Stable',
-                            creator: "Mugz",
                             description: "It is required to remove this add-on before installing and using the A32NX. This add-on overrides A32NX components and renders the A32NX unusable.",
                         },
                         {

--- a/config/config.ts
+++ b/config/config.ts
@@ -157,7 +157,23 @@ const config: Configuration = {
                         },
                         {
                             title: 'LVFR A321neo Extreme',
-                            description: "It is recommended to remove this add-on before installing and using the A32NX. This add-on is known to override A32NX components and to break the A32NX.",
+                            version: '<0.4.0',
+                            description: "It is recommended to upgrade to the latest version (0.4.0 or later) or to remove this add-on before installing and using the A32NX. The older versions of this add-on are known to override A32NX components and to break the A32NX.",
+                        },
+                        {
+                            title: 'Horizon Simulations A321neo',
+                            version: '<0.4.0',
+                            description: "It is recommended to upgrade to the latest version (0.4.0 or later) or to remove this add-on before installing and using the A32NX. The older versions of this add-on are known to override A32NX components and to break the A32NX.",
+                        },
+                        {
+                            title: 'lvfr-airbus-a319-fbw-standalone',
+                            version: '<0.6.0',
+                            description: "It is recommended to upgrade to the latest version (0.6.0 or later) or to remove this add-on before installing and using the A32NX. The older versions of this add-on are known to override A32NX components and to break the A32NX.",
+                        },
+                        {
+                            title: 'Horizon Simulations A319ceo',
+                            version: '<0.6.0',
+                            description: "It is recommended to upgrade to the latest version (0.6.0 or later) or to remove this add-on before installing and using the A32NX. The older versions of this add-on are known to override A32NX components and to break the A32NX.",
                         },
                         {
                             title: '[MOD] Mugz FBW A32NX Dev',

--- a/config/config.ts
+++ b/config/config.ts
@@ -188,6 +188,11 @@ const config: Configuration = {
                             creator: "AmbitiousPilots",
                             description: "This add-on sometimes causes performance issues and also sometimes prevents the A32NX from taxiing. Consider removing it if you experience these issues.",
                         },
+                        {
+                            title: 'Asobo_A320_A (A32NX Converted)',
+                            creator: "UnitDeath",
+                            description: "It is required to remove this livery before installing and using the A32NX as it breaks the A32NX",
+                        }
                     ],
                     myInstallPage: {
                         links: [

--- a/config/config.ts
+++ b/config/config.ts
@@ -157,13 +157,11 @@ const config: Configuration = {
                         },
                         {
                             title: 'LVFR A321neo Extreme',
-                            packageVersion: '<0.4.0',
-                            description: "It is recommended to upgrade to the latest version (0.4.0 or later) or to remove this add-on before installing and using the A32NX. The older versions of this add-on are known to override A32NX components and to break the A32NX.",
+                            description: "It is recommended to remove this add-on before installing and using the A32NX. This add-on is known to override A32NX components and cause unexpected behavior and issues when flying the A32NX.",
                         },
                         {
                             title: 'Horizon Simulations A321neo',
-                            packageVersion: '<0.4.0',
-                            description: "It is recommended to upgrade to the latest version (0.4.0 or later) or to remove this add-on before installing and using the A32NX. The older versions of this add-on are known to override A32NX components and to break the A32NX.",
+                            description: "It is recommended to remove this add-on before installing and using the A32NX. This add-on is known to override A32NX components and cause unexpected behavior and issues when flying the A32NX.",
                         },
                         {
                             title: 'lvfr-airbus-a319-fbw-standalone',

--- a/config/config.ts
+++ b/config/config.ts
@@ -157,22 +157,22 @@ const config: Configuration = {
                         },
                         {
                             title: 'LVFR A321neo Extreme',
-                            version: '<0.4.0',
+                            packageVersion: '<0.4.0',
                             description: "It is recommended to upgrade to the latest version (0.4.0 or later) or to remove this add-on before installing and using the A32NX. The older versions of this add-on are known to override A32NX components and to break the A32NX.",
                         },
                         {
                             title: 'Horizon Simulations A321neo',
-                            version: '<0.4.0',
+                            packageVersion: '<0.4.0',
                             description: "It is recommended to upgrade to the latest version (0.4.0 or later) or to remove this add-on before installing and using the A32NX. The older versions of this add-on are known to override A32NX components and to break the A32NX.",
                         },
                         {
                             title: 'lvfr-airbus-a319-fbw-standalone',
-                            version: '<0.6.0',
+                            packageVersion: '<0.6.0',
                             description: "It is recommended to upgrade to the latest version (0.6.0 or later) or to remove this add-on before installing and using the A32NX. The older versions of this add-on are known to override A32NX components and to break the A32NX.",
                         },
                         {
                             title: 'Horizon Simulations A319ceo',
-                            version: '<0.6.0',
+                            packageVersion: '<0.6.0',
                             description: "It is recommended to upgrade to the latest version (0.6.0 or later) or to remove this add-on before installing and using the A32NX. The older versions of this add-on are known to override A32NX components and to break the A32NX.",
                         },
                         {

--- a/config/config.ts
+++ b/config/config.ts
@@ -160,7 +160,7 @@ const config: Configuration = {
                         },
                         {
                             title: 'Horizon Simulations A321neo',
-                            packageVersion: '<0.4.0',
+                            // packageVersion: '<0.4.0', see https://discord.com/channels/738864299392630914/785976111875751956/1055617417189011546
                             description: "It is recommended to remove this add-on before installing and using the A32NX. This add-on is known to override A32NX components and cause unexpected behavior and issues when flying the A32NX.",
                         },
                         {


### PR DESCRIPTION
Ran tests for multiple addons
https://docs.google.com/spreadsheets/d/1giJBVY2rhxERBV-c76BD2-WApqRC74uZOlTPYE4HPEk/edit?usp=sharing

Based on that, the Horizon Simulation Addons should have a version check. 

* A319 is fixed in 0.6.0 and later
* A321 will be fixed in 0.4.0 and later

Both the addons are also changing their manifest title, this PR will catch the different manifest titles:
https://github.com/markszutor/LVFR-A319ceo-FBW-Compatibility-mod/commit/b020efd260807807787b709e014e83207f416e7b
https://github.com/markszutor/LVFR-A321neo-FBW-Compatibility-mod/commit/1cef8d18239d840738f06cfbca55c6f095a1d34e
