### PR TITLE
blacklist wxr mod

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -211,6 +211,11 @@ const config: Configuration = {
                             creator: "Nicottine",
                             description: "It is required to remove this add-on before installing and using the A32NX. This add-on overrides A32NX components and renders the A32NX unusable.",
                         },
+                        {
+                            title: "FBW A32NX Weather Radar Mod",
+                            creator: "",
+                            description: "It is required to remove this add-on before installing and using the A32NX. This add-on overrides A32NX components may render the A32NX unusable."
+                        }
                     ],
                     myInstallPage: {
                         links: [


### PR DESCRIPTION
Blacklist https://flightsim.to/file/57681/weather-radar-mod-for-fbw-a320-neo-development-version as it overwrites the following A32NX files in the VFS:
- html_ui/Pages/VCockpit/Instruments/A32NX/ND/nd.css
- html_ui/Pages/VCockpit/Instruments/A32NX/ND/nd.html
- html_ui/Pages/VCockpit/Instruments/A32NX/ND/nd.js

manifest (note creator field is empty!):
```json
{
  "creator": "",
  "release_notes": {
    "neutral": {
      "LastUpdate": "",
      "OlderHistory": ""
    }
  },
  "title": "FBW A32NX Weather Radar Mod",
  "dependencies": [],
  "content_type": "AIRCRAFT",
  "minimum_game_version": "1.26.5",
  "manufacturer": "Airbus",
  "package_version": "1.0.0",
  "total_package_size": "00000000003080027747"
}
```