### PR TITLE
Fix: Updated A380X Model Type

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -242,7 +242,7 @@ const config: Configuration = {
                     repoOwner: 'flybywiresim',
                     repoName: 'aircraft',
                     category: '@aircraft',
-                    aircraftName: 'A380-841',
+                    aircraftName: 'A380-842',
                     titleImageUrl: 'https://flybywiresim.b-cdn.net/installer/media-assets/addon-titles/fbw-a380x/dark.svg',
                     titleImageUrlSelected: 'https://flybywiresim.b-cdn.net/installer/media-assets/addon-titles/fbw-a380x/light.svg',
                     enabled: false,


### PR DESCRIPTION
Changed the A380X type from A380-841 to A380-842 to accurately represent the model under development.

Reference : https://github.com/flybywiresim/aircraft/tree/master/fbw-a380x/src/base/flybywire-aircraft-a380-842