### PR TITLE
docs: update README with new CDN url

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ The aim of this project is to provide a means to separate the installer configur
 
 The configuration is defined in the `config.ts` file.
 
-Once merged to staging, the configuration is automatically deployed to the CDN (`https://cdn.flybywiresim.com/installer/config/staging.json`).
+Once merged to staging, the configuration is automatically deployed to the CDN (`https://flybywirecdn.com/installer/config/staging.json`).
 
-A maintainer can then manually deploy the configuration to the production branch (`https://cdn.flybywiresim.com/installer/config/production.json`).
+A maintainer can then manually deploy the configuration to the production branch (`https://flybywirecdn.com/installer/config/production.json`).
 
 ## Contributing
 
@@ -23,7 +23,7 @@ To change the configuration, please submit a pull request with your changes to t
 
 To build the configuration locally, run `npm run build <filename>`. The resulting json file will be placed in the `dist` folder. This is only for testing purposes. You can use the file to test your configuration locally by using this URL: `file://{path to json file}`
 
-If a PR is created from a branch of the main repo (and not a fork) the configuration will be automatically build and deployed to the CDN. The URL will be `https://cdn.flybywiresim.com/installer/config/pr-<PR-NUMBER>.json`.
+If a PR is created from a branch of the main repo (and not a fork) the configuration will be automatically build and deployed to the CDN. The URL will be `https://flybywirecdn.com/installer/config/pr-<PR-NUMBER>.json`.
 
 For testing the PR configuration copy the URL and paste it into the installer configuration URL field in the installer settings. Ask on the FlyByWire's Discord [#installer](https://discord.com/channels/738864299392630914/757387126173204540) channel on how to do this.
 


### PR DESCRIPTION
Updates the repo README to reflects changes made in https://github.com/flybywiresim/installer/pull/490