### PR TITLE
chore: add a380 brightlight mod to incompatible list

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -363,8 +363,11 @@ const config: Configuration = {
                             description: "It is required to remove this add-on before installing and using the A380X. This add-on overrides " +
                                 "A380X components and may render the A380X unusable."
                         },
-
-
+                        {
+                            title: 'Bright_Light_A380',
+                            description: "It is required to remove this add-on before installing and using the A380X. This add-on overrides " +
+                                "A380X components and may render the A380X unusable."
+			},
                     ],
                     disallowedRunningExternalApps: ['@/msfs'],
                 },


### PR DESCRIPTION
https://flightsim.to/file/83946/bright-light-fbw-a380x

Overrides the main cockpit model behaviour file. Breaks at least the OIT, and no doubt more.

layout.json:
```json
{
  "content": [
    {
      "path": "SimObjects/Airplanes/FlyByWire_A380_842/model/A380_COCKPIT.xml",
      "size": 329680,
      "date": 133749503327797488
    },
    {
      "path": "SimObjects/Airplanes/FlyByWire_A380_842/texture/PUSH_TEXT_EMIS.PNG.DDS",
      "size": 16777344,
      "date": 133749479848024871
    },
    {
      "path": "SimObjects/Airplanes/FlyByWire_A380_842/texture/PUSH_TEXT_EMIS.PNG.DDS.json",
      "size": 102,
      "date": 133749606864246465
    }
  ]
}
```
manifest.json
```json
{
  "creator": "FlyByWire Simulations",
  "release_notes": {
    "neutral": {
      "LastUpdate": "",
      "OlderHistory": ""
    }
  },
  "title": "Bright_Light_A380",
  "dependencies": [
    {
      "package_version": "0.1.129",
      "name": "asobo-vcockpits-instruments-airliners"
    },
    {
      "package_version": "0.1.125",
      "name": "fs-base-aircraft-common"
    }
  ],
  "content_type": "AIRCRAFT",
  "minimum_game_version": "1.26.5",
  "manufacturer": "Airbus",
  "package_version": "0.12.0-f26029363ad3edeeafbed20aa79c13b32c8090f8",
  "total_package_size": "00000000000017108235"
}
```