### PR TITLE
fix: simbridge docs url

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -763,7 +763,7 @@ const config: Configuration = {
                     myInstallPage: {
                         links: [
                             {
-                                url: 'https://docs.flybywiresim.com/simbridge/',
+                                url: 'https://docs.flybywiresim.com/tools/simbridge/',
                                 title: 'Documentation',
                             },
                         ],
@@ -819,7 +819,7 @@ const config: Configuration = {
                     myInstallPage: {
                         links: [
                             {
-                                url: 'https://docs.flybywiresim.com/simbridge/',
+                                url: 'https://docs.flybywiresim.com/tools/simbridge/',
                                 title: 'Documentation',
                             },
                         ],


### PR DESCRIPTION
- updates outdated simbridge docs url to latest one following https://github.com/flybywiresim/docs/pull/961/
(yes, in over two years, no one has noticed)