### PR TITLE
feat: split fbw msfs 2020 and 2024 addons

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -92,12 +92,12 @@ const config: Configuration = {
                         {
                             name: 'Development',
                             key: 'a32nx-dev',
-                            url: 'https://flybywirecdn.com/addons/a32nx/master',
+                            url: 'https://flybywirecdn.com/addons/msfs2020/a32nx/master',
                             alternativeUrls: [
+                                'external/msfs2020/a32nx/master',
                                 // move old experimental users over to dev
                                 'https://cdn.flybywiresim.com/addons/a32nx/cfbw-cap',
                                 'https://cdn.flybywiresim.com/addons/a32nx/cfbw',
-                                'external/a32nx/master',
                                 // move bunnycdn users to cloudflare
                                 'https://cdn.flybywiresim.com/addons/a32nx/master',
                                 // move exp users to dev
@@ -105,6 +105,9 @@ const config: Configuration = {
                                 'external/a32nx/experimental',
                                 'https://cdn.flybywiresim.com/addons/a32nx/experimental',
                                 'https://github.com/flybywiresim/a32nx/releases/download/assets/experimental/',
+                                // pre-split
+                                'external/a32nx/master',
+                                'https://flybywirecdn.com/addons/a32nx/master'
                             ],
                             description: 'The development edition has all of the latest features and bug fixes that will end up in the next stable edition release. ' +
                                 'Although every change is QA-tested, bugs sometimes slip in; please reach out to us if you find any. ' +
@@ -117,11 +120,14 @@ const config: Configuration = {
                         {
                             name: 'Stable',
                             key: 'a32nx-stable',
-                            url: 'https://flybywirecdn.com/addons/a32nx/stable',
+                            url: 'https://flybywirecdn.com/addons/msfs2020/a32nx/stable',
                             alternativeUrls: [
-                                'external/a32nx/stable',
+                                'external/msfs2020/a32nx/stable',
                                 // move bunnycdn users to cloudflare
                                 'https://cdn.flybywiresim.com/addons/a32nx/stable',
+                                // pre-split
+                                'external/a32nx/stable',
+                                'https://flybywirecdn.com/addons/a32nx/stable'
                             ],
                             description: 'The stable edition is for those who need a stable home cockpit API, or controlled upgrades every few months. ' +
                                 'This edition will always be behind the development edition in both features and fixes, ' +
@@ -284,9 +290,12 @@ const config: Configuration = {
                         {
                             name: 'Development',
                             key: 'a32nx-dev',
-                            url: 'https://flybywirecdn.com/addons/a32nx/master',
+                            url: 'https://flybywirecdn.com/addons/msfs2024/a32nx/master',
                             alternativeUrls: [
+                                'external/msfs2024/a32nx/master',
+                                // pre-split
                                 'external/a32nx/master',
+                                'https://flybywirecdn.com/addons/a32nx/master',
                             ],
                             description: 'The development edition has all of the latest features and bug fixes that will end up in the next stable edition release. ' +
                                 'Although every change is QA-tested, bugs sometimes slip in; please reach out to us if you find any. ' +
@@ -299,9 +308,12 @@ const config: Configuration = {
                         {
                             name: 'Stable',
                             key: 'a32nx-stable',
-                            url: 'https://flybywirecdn.com/addons/a32nx/stable',
+                            url: 'https://flybywirecdn.com/addons/msfs2024/a32nx/stable',
                             alternativeUrls: [
+                                'external/msfs2024/a32nx/stable',
+                                // pre-split
                                 'external/a32nx/stable',
+                                'https://flybywirecdn.com/addons/a32nx/stable'
                             ],
                             description: 'The stable edition is for those who need a stable home cockpit API, or controlled upgrades every few months. ' +
                                 'This edition will always be behind the development edition in both features and fixes, ' +
@@ -450,8 +462,13 @@ const config: Configuration = {
                         {
                             name: 'Development (4K)',
                             key: 'a380x-dev-4k',
-                            url: 'https://flybywirecdn.com/addons/a380x/master-4k',
-                            alternativeUrls: [],
+                            url: 'https://flybywirecdn.com/addons/msfs2020/a380x/master-4k',
+                            alternativeUrls: [
+                                'external/msfs2020/a380x/master-4k',
+                                //pre-split
+                                'external/a380x/master-4k',
+                                'https://flybywirecdn.com/addons/a380x/master-4k'
+                            ],
                             description: 'Development will have the latest features that will end up in the next stable. ' +
                                 'Although every change is QA-tested, bugs are a little more likely. It updates whenever something is added to ' +
                                 'the \'master\' branch on Github. Please visit our discord for support. \n\n' +
@@ -470,8 +487,13 @@ const config: Configuration = {
                         {
                             name: 'Development (8K)',
                             key: 'a380x-dev-8k',
-                            url: 'https://flybywirecdn.com/addons/a380x/master-8k',
-                            alternativeUrls: [],
+                            url: 'https://flybywirecdn.com/addons/msfs2020/a380x/master-8k',
+                            alternativeUrls: [
+                                'external/msfs2020/a380x/master-8k',
+                                //pre-split
+                                'external/a380x/master-8k',
+                                'https://flybywirecdn.com/addons/a380x/master-8k'
+                            ],
                             description: 'Development will have the latest features that will end up in the next stable. ' +
                                 'Although every change is QA-tested, bugs are a little more likely. It updates whenever something is added to ' +
                                 'the \'master\' branch on Github. Please visit our discord for support. \n\n' +
@@ -485,8 +507,13 @@ const config: Configuration = {
                         {
                             name: 'Stable (4K)',
                             key: 'a380x-stable-4k',
-                            url: 'https://flybywirecdn.com/addons/a380x/stable-4k',
-                            alternativeUrls: [],
+                            url: 'https://flybywirecdn.com/addons/msfs2020/a380x/stable-4k',
+                            alternativeUrls: [
+                                'external/msfs2020/a380x/stable-4k',
+                                //pre-split
+                                'external/a380x/stable-4k',
+                                'https://flybywirecdn.com/addons/a380x/stable-4k'
+                            ],
                             description: 'Includes our 4K downscaled cabin, cockpit and exterior textures. Choose this option for reduced ' +
                                 'stutters, better performance, with HIGH or lower texture resolution. Especially, if you intend to use the ' +
                                 'following:\n\n' +
@@ -503,8 +530,13 @@ const config: Configuration = {
                         {
                             name: 'Stable (8K)',
                             key: 'a380x-stable-8k',
-                            url: 'https://flybywirecdn.com/addons/a380x/stable-8k',
-                            alternativeUrls: [],
+                            url: 'https://flybywirecdn.com/addons/msfs2020/a380x/stable-8k',
+                            alternativeUrls: [
+                                'external/msfs2020/a380x/stable-8k',
+                                //pre-split
+                                'external/a380x/stable-8k',
+                                'https://flybywirecdn.com/addons/a380x/stable-8k'
+                            ],
                             description: 'Includes our 8K full resolution cabin, cockpit and exterior textures. This is the full fidelity ' +
                                 'experience and our recommendation if your system is powerful enough to support it. Realistic and in high ' +
                                 'detail.\n\n' +
@@ -586,8 +618,13 @@ const config: Configuration = {
                         {
                             name: 'Development (4K)',
                             key: 'a380x-dev-4k',
-                            url: 'https://flybywirecdn.com/addons/a380x/master-4k',
-                            alternativeUrls: [],
+                            url: 'https://flybywirecdn.com/addons/msfs2024/a380x/master-4k',
+                            alternativeUrls: [
+                                'external/msfs2024/a380x/master-4k',
+                                //pre-split
+                                'external/a380x/master-4k',
+                                'https://flybywirecdn.com/addons/a380x/master-4k'
+                            ],
                             description: 'Development will have the latest features that will end up in the next stable. ' +
                                 'Although every change is QA-tested, bugs are a little more likely. It updates whenever something is added to ' +
                                 'the \'master\' branch on Github. Please visit our discord for support. \n\n' +
@@ -606,8 +643,13 @@ const config: Configuration = {
                         {
                             name: 'Development (8K)',
                             key: 'a380x-dev-8k',
-                            url: 'https://flybywirecdn.com/addons/a380x/master-8k',
-                            alternativeUrls: [],
+                            url: 'https://flybywirecdn.com/addons/msfs2024/a380x/master-8k',
+                            alternativeUrls: [
+                                'external/msfs2024/a380x/master-8k',
+                                //pre-split
+                                'external/a380x/master-8k',
+                                'https://flybywirecdn.com/addons/a380x/master-8k'
+                            ],
                             description: 'Development will have the latest features that will end up in the next stable. ' +
                                 'Although every change is QA-tested, bugs are a little more likely. It updates whenever something is added to ' +
                                 'the \'master\' branch on Github. Please visit our discord for support. \n\n' +
@@ -621,8 +663,13 @@ const config: Configuration = {
                         {
                             name: 'Stable (4K)',
                             key: 'a380x-stable-4k',
-                            url: 'https://flybywirecdn.com/addons/a380x/stable-4k',
-                            alternativeUrls: [],
+                            url: 'https://flybywirecdn.com/addons/msfs2024/a380x/stable-4k',
+                            alternativeUrls: [
+                                'external/msfs2024/a380x/stable-4k',
+                                //pre-split
+                                'external/a380x/stable-4k',
+                                'https://flybywirecdn.com/addons/a380x/stable-4k'
+                            ],
                             description: 'Includes our 4K downscaled cabin, cockpit and exterior textures. Choose this option for reduced ' +
                                 'stutters, better performance, with HIGH or lower texture resolution. Especially, if you intend to use the ' +
                                 'following:\n\n' +
@@ -639,8 +686,13 @@ const config: Configuration = {
                         {
                             name: 'Stable (8K)',
                             key: 'a380x-stable-8k',
-                            url: 'https://flybywirecdn.com/addons/a380x/stable-8k',
-                            alternativeUrls: [],
+                            url: 'https://flybywirecdn.com/addons/msfs2024/a380x/stable-8k',
+                            alternativeUrls: [
+                                'external/msfs2024/a380x/stable-8k',
+                                //pre-split
+                                'external/a380x/stable-8k',
+                                'https://flybywirecdn.com/addons/a380x/stable-8k'
+                            ],
                             description: 'Includes our 8K full resolution cabin, cockpit and exterior textures. This is the full fidelity ' +
                                 'experience and our recommendation if your system is powerful enough to support it. Realistic and in high ' +
                                 'detail.\n\n' +

--- a/config/config.ts
+++ b/config/config.ts
@@ -109,7 +109,9 @@ const config: Configuration = {
                                 'https://cdn.flybywiresim.com/addons/a32nx/experimental',
                                 'https://github.com/flybywiresim/a32nx/releases/download/assets/experimental/',
                             ],
-                            description: 'The development edition has all of the latest features and bug fixes that will end up in the next stable edition release. ' +
+                            description:
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2020 (MSFS2020).<br />For use with MSFS2024, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                'The development edition has all of the latest features and bug fixes that will end up in the next stable edition release. ' +
                                 'Although every change is QA-tested, bugs sometimes slip in; please reach out to us if you find any. ' +
                                 'Updates occur whenever something is added to the \'master\' branch on Github. Please visit our discord for support.',
                             isExperimental: false,
@@ -129,7 +131,9 @@ const config: Configuration = {
                                 'external/a32nx/stable',
                                 'https://flybywirecdn.com/addons/a32nx/stable',
                             ],
-                            description: 'The stable edition is for those who need a stable home cockpit API, or controlled upgrades every few months. ' +
+                            description:
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2020 (MSFS2020).<br />For use with MSFS2024, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                'The stable edition is for those who need a stable home cockpit API, or controlled upgrades every few months. ' +
                                 'This edition will always be behind the development edition in both features and fixes, ' +
                                 'but it will receive compatibility patches if required for MSFS updates. Please visit our discord for support.',
                             isExperimental: false,
@@ -297,7 +301,9 @@ const config: Configuration = {
                                 'external/a32nx/master',
                                 'https://flybywirecdn.com/addons/a32nx/master',
                             ],
-                            description: 'The development edition has all of the latest features and bug fixes that will end up in the next stable edition release. ' +
+                            description:
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2024 (MSFS2024).<br />For use with MSFS2020, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                'The development edition has all of the latest features and bug fixes that will end up in the next stable edition release. ' +
                                 'Although every change is QA-tested, bugs sometimes slip in; please reach out to us if you find any. ' +
                                 'Updates occur whenever something is added to the \'master\' branch on Github. Please visit our discord for support.',
                             isExperimental: false,
@@ -315,7 +321,9 @@ const config: Configuration = {
                                 'external/a32nx/stable',
                                 'https://flybywirecdn.com/addons/a32nx/stable',
                             ],
-                            description: 'The stable edition is for those who need a stable home cockpit API, or controlled upgrades every few months. ' +
+                            description:
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2024 (MSFS2024).<br />For use with MSFS2020, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                'The stable edition is for those who need a stable home cockpit API, or controlled upgrades every few months. ' +
                                 'This edition will always be behind the development edition in both features and fixes, ' +
                                 'but it will receive compatibility patches if required for MSFS updates. Please visit our discord for support.',
                             isExperimental: false,
@@ -469,7 +477,9 @@ const config: Configuration = {
                                 'external/a380x/master-4k',
                                 'https://flybywirecdn.com/addons/a380x/master-4k',
                             ],
-                            description: 'Development will have the latest features that will end up in the next stable. ' +
+                            description:
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2020 (MSFS2020).<br />For use with MSFS2024, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                'Development will have the latest features that will end up in the next stable. ' +
                                 'Although every change is QA-tested, bugs are a little more likely. It updates whenever something is added to ' +
                                 'the \'master\' branch on Github. Please visit our discord for support. \n\n' +
                                 'Includes our 4K downscaled cabin, cockpit and exterior textures. Choose this option for reduced ' +
@@ -494,7 +504,9 @@ const config: Configuration = {
                                 'external/a380x/master-8k',
                                 'https://flybywirecdn.com/addons/a380x/master-8k',
                             ],
-                            description: 'Development will have the latest features that will end up in the next stable. ' +
+                            description:
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2020 (MSFS2020).<br />For use with MSFS2024, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                'Development will have the latest features that will end up in the next stable. ' +
                                 'Although every change is QA-tested, bugs are a little more likely. It updates whenever something is added to ' +
                                 'the \'master\' branch on Github. Please visit our discord for support. \n\n' +
                                 '* DX11 recommended \n\n' +
@@ -514,7 +526,9 @@ const config: Configuration = {
                                 'external/a380x/stable-4k',
                                 'https://flybywirecdn.com/addons/a380x/stable-4k',
                             ],
-                            description: 'Includes our 4K downscaled cabin, cockpit and exterior textures. Choose this option for reduced ' +
+                            description:
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2020 (MSFS2020).<br />For use with MSFS2024, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                'Includes our 4K downscaled cabin, cockpit and exterior textures. Choose this option for reduced ' +
                                 'stutters, better performance, with HIGH or lower texture resolution. Especially, if you intend to use the ' +
                                 'following:\n\n' +
                                 '* Use frame generation \n\n' +
@@ -537,7 +551,9 @@ const config: Configuration = {
                                 'external/a380x/stable-8k',
                                 'https://flybywirecdn.com/addons/a380x/stable-8k',
                             ],
-                            description: 'Includes our 8K full resolution cabin, cockpit and exterior textures. This is the full fidelity ' +
+                            description:
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2020 (MSFS2020).<br />For use with MSFS2024, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                'Includes our 8K full resolution cabin, cockpit and exterior textures. This is the full fidelity ' +
                                 'experience and our recommendation if your system is powerful enough to support it. Realistic and in high ' +
                                 'detail.\n\n' +
                                 '* DX11 recommended \n\n' +
@@ -625,7 +641,9 @@ const config: Configuration = {
                                 'external/a380x/master-4k',
                                 'https://flybywirecdn.com/addons/a380x/master-4k',
                             ],
-                            description: 'Development will have the latest features that will end up in the next stable. ' +
+                            description:
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2024 (MSFS2024).<br />For use with MSFS2020, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                'Development will have the latest features that will end up in the next stable. ' +
                                 'Although every change is QA-tested, bugs are a little more likely. It updates whenever something is added to ' +
                                 'the \'master\' branch on Github. Please visit our discord for support. \n\n' +
                                 'Includes our 4K downscaled cabin, cockpit and exterior textures. Choose this option for reduced ' +
@@ -650,7 +668,9 @@ const config: Configuration = {
                                 'external/a380x/master-8k',
                                 'https://flybywirecdn.com/addons/a380x/master-8k',
                             ],
-                            description: 'Development will have the latest features that will end up in the next stable. ' +
+                            description:
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2024 (MSFS2024).<br />For use with MSFS2020, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                'Development will have the latest features that will end up in the next stable. ' +
                                 'Although every change is QA-tested, bugs are a little more likely. It updates whenever something is added to ' +
                                 'the \'master\' branch on Github. Please visit our discord for support. \n\n' +
                                 '* DX11 recommended \n\n' +
@@ -670,7 +690,9 @@ const config: Configuration = {
                                 'external/a380x/stable-4k',
                                 'https://flybywirecdn.com/addons/a380x/stable-4k',
                             ],
-                            description: 'Includes our 4K downscaled cabin, cockpit and exterior textures. Choose this option for reduced ' +
+                            description:
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2024 (MSFS2024).<br />For use with MSFS2020, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                'Includes our 4K downscaled cabin, cockpit and exterior textures. Choose this option for reduced ' +
                                 'stutters, better performance, with HIGH or lower texture resolution. Especially, if you intend to use the ' +
                                 'following:\n\n' +
                                 '* Use frame generation \n\n' +
@@ -693,7 +715,9 @@ const config: Configuration = {
                                 'external/a380x/stable-8k',
                                 'https://flybywirecdn.com/addons/a380x/stable-8k',
                             ],
-                            description: 'Includes our 8K full resolution cabin, cockpit and exterior textures. This is the full fidelity ' +
+                            description:
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2024 (MSFS2024).<br />For use with MSFS2020, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                'Includes our 8K full resolution cabin, cockpit and exterior textures. This is the full fidelity ' +
                                 'experience and our recommendation if your system is powerful enough to support it. Realistic and in high ' +
                                 'detail.\n\n' +
                                 '* DX11 recommended \n\n' +

--- a/config/config.ts
+++ b/config/config.ts
@@ -95,6 +95,9 @@ const config: Configuration = {
                             url: 'https://flybywirecdn.com/addons/msfs2020/a32nx/master',
                             alternativeUrls: [
                                 'external/msfs2020/a32nx/master',
+                                // pre-split
+                                'external/a32nx/master',
+                                'https://flybywirecdn.com/addons/a32nx/master',
                                 // move old experimental users over to dev
                                 'https://cdn.flybywiresim.com/addons/a32nx/cfbw-cap',
                                 'https://cdn.flybywiresim.com/addons/a32nx/cfbw',
@@ -105,9 +108,6 @@ const config: Configuration = {
                                 'external/a32nx/experimental',
                                 'https://cdn.flybywiresim.com/addons/a32nx/experimental',
                                 'https://github.com/flybywiresim/a32nx/releases/download/assets/experimental/',
-                                // pre-split
-                                'external/a32nx/master',
-                                'https://flybywirecdn.com/addons/a32nx/master'
                             ],
                             description: 'The development edition has all of the latest features and bug fixes that will end up in the next stable edition release. ' +
                                 'Although every change is QA-tested, bugs sometimes slip in; please reach out to us if you find any. ' +

--- a/config/config.ts
+++ b/config/config.ts
@@ -110,7 +110,7 @@ const config: Configuration = {
                                 'https://github.com/flybywiresim/a32nx/releases/download/assets/experimental/',
                             ],
                             description:
-                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2020 (MSFS2020).<br />For use with MSFS2024, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2020 (MSFS2020).<br />For use with MSFS2024, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank" style="color: rgb(255, 106, 0);">Read more</a></span> \n\n` +
                                 'The development edition has all of the latest features and bug fixes that will end up in the next stable edition release. ' +
                                 'Although every change is QA-tested, bugs sometimes slip in; please reach out to us if you find any. ' +
                                 'Updates occur whenever something is added to the \'master\' branch on Github. Please visit our discord for support.',
@@ -132,7 +132,7 @@ const config: Configuration = {
                                 'https://flybywirecdn.com/addons/a32nx/stable',
                             ],
                             description:
-                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2020 (MSFS2020).<br />For use with MSFS2024, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2020 (MSFS2020).<br />For use with MSFS2024, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank" style="color: rgb(255, 106, 0);">Read more</a></span> \n\n` +
                                 'The stable edition is for those who need a stable home cockpit API, or controlled upgrades every few months. ' +
                                 'This edition will always be behind the development edition in both features and fixes, ' +
                                 'but it will receive compatibility patches if required for MSFS updates. Please visit our discord for support.',
@@ -302,7 +302,7 @@ const config: Configuration = {
                                 'https://flybywirecdn.com/addons/a32nx/master',
                             ],
                             description:
-                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2024 (MSFS2024).<br />For use with MSFS2020, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2024 (MSFS2024).<br />For use with MSFS2020, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank" style="color: rgb(255, 106, 0);">Read more</a></span> \n\n` +
                                 'The development edition has all of the latest features and bug fixes that will end up in the next stable edition release. ' +
                                 'Although every change is QA-tested, bugs sometimes slip in; please reach out to us if you find any. ' +
                                 'Updates occur whenever something is added to the \'master\' branch on Github. Please visit our discord for support.',
@@ -322,7 +322,7 @@ const config: Configuration = {
                                 'https://flybywirecdn.com/addons/a32nx/stable',
                             ],
                             description:
-                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2024 (MSFS2024).<br />For use with MSFS2020, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2024 (MSFS2024).<br />For use with MSFS2020, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank" style="color: rgb(255, 106, 0);">Read more</a></span> \n\n` +
                                 'The stable edition is for those who need a stable home cockpit API, or controlled upgrades every few months. ' +
                                 'This edition will always be behind the development edition in both features and fixes, ' +
                                 'but it will receive compatibility patches if required for MSFS updates. Please visit our discord for support.',
@@ -478,7 +478,7 @@ const config: Configuration = {
                                 'https://flybywirecdn.com/addons/a380x/master-4k',
                             ],
                             description:
-                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2020 (MSFS2020).<br />For use with MSFS2024, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2020 (MSFS2020).<br />For use with MSFS2024, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank" style="color: rgb(255, 106, 0);">Read more</a></span> \n\n` +
                                 'Development will have the latest features that will end up in the next stable. ' +
                                 'Although every change is QA-tested, bugs are a little more likely. It updates whenever something is added to ' +
                                 'the \'master\' branch on Github. Please visit our discord for support. \n\n' +
@@ -505,7 +505,7 @@ const config: Configuration = {
                                 'https://flybywirecdn.com/addons/a380x/master-8k',
                             ],
                             description:
-                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2020 (MSFS2020).<br />For use with MSFS2024, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2020 (MSFS2020).<br />For use with MSFS2024, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank" style="color: rgb(255, 106, 0);">Read more</a></span> \n\n` +
                                 'Development will have the latest features that will end up in the next stable. ' +
                                 'Although every change is QA-tested, bugs are a little more likely. It updates whenever something is added to ' +
                                 'the \'master\' branch on Github. Please visit our discord for support. \n\n' +
@@ -527,7 +527,7 @@ const config: Configuration = {
                                 'https://flybywirecdn.com/addons/a380x/stable-4k',
                             ],
                             description:
-                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2020 (MSFS2020).<br />For use with MSFS2024, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2020 (MSFS2020).<br />For use with MSFS2024, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank" style="color: rgb(255, 106, 0);">Read more</a></span> \n\n` +
                                 'Includes our 4K downscaled cabin, cockpit and exterior textures. Choose this option for reduced ' +
                                 'stutters, better performance, with HIGH or lower texture resolution. Especially, if you intend to use the ' +
                                 'following:\n\n' +
@@ -552,7 +552,7 @@ const config: Configuration = {
                                 'https://flybywirecdn.com/addons/a380x/stable-8k',
                             ],
                             description:
-                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2020 (MSFS2020).<br />For use with MSFS2024, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2020 (MSFS2020).<br />For use with MSFS2024, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank" style="color: rgb(255, 106, 0);">Read more</a></span> \n\n` +
                                 'Includes our 8K full resolution cabin, cockpit and exterior textures. This is the full fidelity ' +
                                 'experience and our recommendation if your system is powerful enough to support it. Realistic and in high ' +
                                 'detail.\n\n' +
@@ -642,7 +642,7 @@ const config: Configuration = {
                                 'https://flybywirecdn.com/addons/a380x/master-4k',
                             ],
                             description:
-                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2024 (MSFS2024).<br />For use with MSFS2020, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2024 (MSFS2024).<br />For use with MSFS2020, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank" style="color: rgb(255, 106, 0);">Read more</a></span> \n\n` +
                                 'Development will have the latest features that will end up in the next stable. ' +
                                 'Although every change is QA-tested, bugs are a little more likely. It updates whenever something is added to ' +
                                 'the \'master\' branch on Github. Please visit our discord for support. \n\n' +
@@ -669,7 +669,7 @@ const config: Configuration = {
                                 'https://flybywirecdn.com/addons/a380x/master-8k',
                             ],
                             description:
-                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2024 (MSFS2024).<br />For use with MSFS2020, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2024 (MSFS2024).<br />For use with MSFS2020, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank" style="color: rgb(255, 106, 0);">Read more</a></span> \n\n` +
                                 'Development will have the latest features that will end up in the next stable. ' +
                                 'Although every change is QA-tested, bugs are a little more likely. It updates whenever something is added to ' +
                                 'the \'master\' branch on Github. Please visit our discord for support. \n\n' +
@@ -691,7 +691,7 @@ const config: Configuration = {
                                 'https://flybywirecdn.com/addons/a380x/stable-4k',
                             ],
                             description:
-                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2024 (MSFS2024).<br />For use with MSFS2020, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2024 (MSFS2024).<br />For use with MSFS2020, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank" style="color: rgb(255, 106, 0);">Read more</a></span> \n\n` +
                                 'Includes our 4K downscaled cabin, cockpit and exterior textures. Choose this option for reduced ' +
                                 'stutters, better performance, with HIGH or lower texture resolution. Especially, if you intend to use the ' +
                                 'following:\n\n' +
@@ -716,7 +716,7 @@ const config: Configuration = {
                                 'https://flybywirecdn.com/addons/a380x/stable-8k',
                             ],
                             description:
-                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2024 (MSFS2024).<br />For use with MSFS2020, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank">Read more</a></span> \n\n` +
+                                `<span style="color: rgb(255, 106, 0);">&#9888; Only for Microsoft Flight Simulator 2024 (MSFS2024).<br />For use with MSFS2020, configure your installer for the other simulator.<br /><a href="https://flybywiresim.com/notams/development-update-sim-specific-releases-for-msfs-2020-and-2024/" target="_blank" style="color: rgb(255, 106, 0);">Read more</a></span> \n\n` +
                                 'Includes our 8K full resolution cabin, cockpit and exterior textures. This is the full fidelity ' +
                                 'experience and our recommendation if your system is powerful enough to support it. Realistic and in high ' +
                                 'detail.\n\n' +

--- a/config/config.ts
+++ b/config/config.ts
@@ -127,7 +127,7 @@ const config: Configuration = {
                                 'https://cdn.flybywiresim.com/addons/a32nx/stable',
                                 // pre-split
                                 'external/a32nx/stable',
-                                'https://flybywirecdn.com/addons/a32nx/stable'
+                                'https://flybywirecdn.com/addons/a32nx/stable',
                             ],
                             description: 'The stable edition is for those who need a stable home cockpit API, or controlled upgrades every few months. ' +
                                 'This edition will always be behind the development edition in both features and fixes, ' +
@@ -313,7 +313,7 @@ const config: Configuration = {
                                 'external/msfs2024/a32nx/stable',
                                 // pre-split
                                 'external/a32nx/stable',
-                                'https://flybywirecdn.com/addons/a32nx/stable'
+                                'https://flybywirecdn.com/addons/a32nx/stable',
                             ],
                             description: 'The stable edition is for those who need a stable home cockpit API, or controlled upgrades every few months. ' +
                                 'This edition will always be behind the development edition in both features and fixes, ' +
@@ -467,7 +467,7 @@ const config: Configuration = {
                                 'external/msfs2020/a380x/master-4k',
                                 //pre-split
                                 'external/a380x/master-4k',
-                                'https://flybywirecdn.com/addons/a380x/master-4k'
+                                'https://flybywirecdn.com/addons/a380x/master-4k',
                             ],
                             description: 'Development will have the latest features that will end up in the next stable. ' +
                                 'Although every change is QA-tested, bugs are a little more likely. It updates whenever something is added to ' +
@@ -492,7 +492,7 @@ const config: Configuration = {
                                 'external/msfs2020/a380x/master-8k',
                                 //pre-split
                                 'external/a380x/master-8k',
-                                'https://flybywirecdn.com/addons/a380x/master-8k'
+                                'https://flybywirecdn.com/addons/a380x/master-8k',
                             ],
                             description: 'Development will have the latest features that will end up in the next stable. ' +
                                 'Although every change is QA-tested, bugs are a little more likely. It updates whenever something is added to ' +
@@ -512,7 +512,7 @@ const config: Configuration = {
                                 'external/msfs2020/a380x/stable-4k',
                                 //pre-split
                                 'external/a380x/stable-4k',
-                                'https://flybywirecdn.com/addons/a380x/stable-4k'
+                                'https://flybywirecdn.com/addons/a380x/stable-4k',
                             ],
                             description: 'Includes our 4K downscaled cabin, cockpit and exterior textures. Choose this option for reduced ' +
                                 'stutters, better performance, with HIGH or lower texture resolution. Especially, if you intend to use the ' +
@@ -535,7 +535,7 @@ const config: Configuration = {
                                 'external/msfs2020/a380x/stable-8k',
                                 //pre-split
                                 'external/a380x/stable-8k',
-                                'https://flybywirecdn.com/addons/a380x/stable-8k'
+                                'https://flybywirecdn.com/addons/a380x/stable-8k',
                             ],
                             description: 'Includes our 8K full resolution cabin, cockpit and exterior textures. This is the full fidelity ' +
                                 'experience and our recommendation if your system is powerful enough to support it. Realistic and in high ' +
@@ -623,7 +623,7 @@ const config: Configuration = {
                                 'external/msfs2024/a380x/master-4k',
                                 //pre-split
                                 'external/a380x/master-4k',
-                                'https://flybywirecdn.com/addons/a380x/master-4k'
+                                'https://flybywirecdn.com/addons/a380x/master-4k',
                             ],
                             description: 'Development will have the latest features that will end up in the next stable. ' +
                                 'Although every change is QA-tested, bugs are a little more likely. It updates whenever something is added to ' +
@@ -648,7 +648,7 @@ const config: Configuration = {
                                 'external/msfs2024/a380x/master-8k',
                                 //pre-split
                                 'external/a380x/master-8k',
-                                'https://flybywirecdn.com/addons/a380x/master-8k'
+                                'https://flybywirecdn.com/addons/a380x/master-8k',
                             ],
                             description: 'Development will have the latest features that will end up in the next stable. ' +
                                 'Although every change is QA-tested, bugs are a little more likely. It updates whenever something is added to ' +
@@ -668,7 +668,7 @@ const config: Configuration = {
                                 'external/msfs2024/a380x/stable-4k',
                                 //pre-split
                                 'external/a380x/stable-4k',
-                                'https://flybywirecdn.com/addons/a380x/stable-4k'
+                                'https://flybywirecdn.com/addons/a380x/stable-4k',
                             ],
                             description: 'Includes our 4K downscaled cabin, cockpit and exterior textures. Choose this option for reduced ' +
                                 'stutters, better performance, with HIGH or lower texture resolution. Especially, if you intend to use the ' +
@@ -691,7 +691,7 @@ const config: Configuration = {
                                 'external/msfs2024/a380x/stable-8k',
                                 //pre-split
                                 'external/a380x/stable-8k',
-                                'https://flybywirecdn.com/addons/a380x/stable-8k'
+                                'https://flybywirecdn.com/addons/a380x/stable-8k',
                             ],
                             description: 'Includes our 8K full resolution cabin, cockpit and exterior textures. This is the full fidelity ' +
                                 'experience and our recommendation if your system is powerful enough to support it. Realistic and in high ' +


### PR DESCRIPTION
- splits urls for msfs2020 and msfs2024 version of fbw aircraft addons

related to
https://github.com/flybywiresim/aircraft/pull/10645
https://github.com/flybywiresim/aircraft/pull/10646
